### PR TITLE
Add sample unit tests

### DIFF
--- a/test/auth_notifier_test.dart
+++ b/test/auth_notifier_test.dart
@@ -1,0 +1,83 @@
+import 'package:driver_app/features/auth/domain/entities/auth_user.dart';
+import 'package:driver_app/features/auth/domain/repositories/auth_repository.dart';
+import 'package:driver_app/features/auth/domain/usecases/clear_token.dart';
+import 'package:driver_app/features/auth/domain/usecases/get_saved_token.dart';
+import 'package:driver_app/features/auth/domain/usecases/login.dart';
+import 'package:driver_app/features/auth/domain/usecases/validate_token.dart';
+import 'package:driver_app/features/auth/presentation/providers/auth_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class FakeAuthRepository implements AuthRepository {
+  bool clearCalled = false;
+  @override
+  Future<void> clearToken() async {
+    clearCalled = true;
+  }
+
+  bool validateResult = true;
+  @override
+  Future<bool> validateSavedToken(String token) async => validateResult;
+
+  AuthUser? user;
+  Exception? loginError;
+  @override
+  Future<AuthUser> login(String username, String id) async {
+    if (loginError != null) throw loginError!;
+    user = AuthUser(login_key: id, username: username, jwt_token: 'jwt');
+    return user!;
+  }
+
+  String? savedToken;
+  @override
+  Future<String?> getSavedToken() async => savedToken;
+}
+
+class TestAuthNotifier extends AuthNotifier {
+  TestAuthNotifier(
+    GetSavedToken getSavedToken,
+    ValidateToken validateToken,
+    ClearToken clearToken,
+    Login login,
+  ) : super(getSavedToken, validateToken, clearToken, login);
+
+  @override
+  Future<void> checkSplashStatus() async {}
+}
+
+void main() {
+  group('AuthNotifier', () {
+    late FakeAuthRepository repo;
+    late TestAuthNotifier notifier;
+
+    setUp(() {
+      repo = FakeAuthRepository();
+      notifier = TestAuthNotifier(
+        GetSavedToken(repo),
+        ValidateToken(repo),
+        ClearToken(repo),
+        Login(repo),
+      );
+    });
+
+    test('successful login updates state', () async {
+      await notifier.login('u', '1');
+      expect(notifier.state.user?.username, 'u');
+      expect(notifier.state.token, 'jwt');
+      expect(notifier.state.isLoading, isFalse);
+    });
+
+    test('login failure stores error message', () async {
+      repo.loginError = Exception('fail');
+      await notifier.login('u', '1');
+      expect(notifier.state.errorMessage, contains('fail'));
+      expect(notifier.state.isLoading, isFalse);
+    });
+
+    test('checkToken clears token when invalid', () async {
+      repo.validateResult = false;
+      final result = await notifier.checkToken('t');
+      expect(result, isFalse);
+      expect(repo.clearCalled, isTrue);
+    });
+  });
+}

--- a/test/env_mobile_test.dart
+++ b/test/env_mobile_test.dart
@@ -1,0 +1,23 @@
+import 'package:driver_app/core/env/env_mobile.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Env mobile init', () {
+    test('throws when API_AUTH_URL is missing', () async {
+      await dotenv.testLoad(fileInput: 'WEBSOCKET_RIDE_SERVICE=ws://ws');
+      expect(() => Env.init(), throwsException);
+    });
+
+    test('throws when WEBSOCKET_RIDE_SERVICE is missing', () async {
+      await dotenv.testLoad(fileInput: 'API_AUTH_URL=http://api');
+      expect(() => Env.init(), throwsException);
+    });
+
+    test('sets values when all provided', () async {
+      await dotenv.testLoad(
+          fileInput: 'API_AUTH_URL=http://api\nWEBSOCKET_RIDE_SERVICE=ws://ws');
+      expect(() => Env.init(), returnsNormally);
+    });
+  });
+}

--- a/test/http_response_handler_test.dart
+++ b/test/http_response_handler_test.dart
@@ -1,0 +1,48 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:driver_app/core/http/http_dto.dart';
+import 'package:driver_app/core/http/http_response_handler.dart';
+import 'package:http/http.dart' as http;
+
+void main() {
+  group('responseHandler', () {
+    test('returns content for successful response', () async {
+      final body = json.encode({
+        'content': 'ok',
+        'success': true,
+        'error': ''
+      });
+      final response = http.Response(body, 200);
+      final result = await responseHandler<String>(
+        response,
+        (json) => json as String,
+      );
+      expect(result, equals('ok'));
+    });
+
+    test('throws message from body on 400', () async {
+      final body = json.encode({'error': 'bad request'});
+      final response = http.Response(body, 400);
+      expect(
+        () => responseHandler<String>(response, (json) => json as String),
+        throwsA('bad request'),
+      );
+    });
+
+    test('throws default message on missing error field', () async {
+      final response = http.Response('{}', 401);
+      expect(
+        () => responseHandler<String>(response, (json) => json as String),
+        throwsA('משתמש לא מורשה'),
+      );
+    });
+
+    test('throws generic message for unexpected status', () async {
+      final response = http.Response('oops', 500);
+      expect(
+        () => responseHandler<String>(response, (json) => json as String),
+        throwsA('שגיאה כללית בשרת (500)'),
+      );
+    });
+  });
+}

--- a/test/ride_repository_impl_test.dart
+++ b/test/ride_repository_impl_test.dart
@@ -1,0 +1,53 @@
+import 'package:driver_app/core/websocket/websocket_dto.dart';
+import 'package:driver_app/features/rides/data/datasources/rides_websocket_datasource.dart';
+import 'package:driver_app/features/rides/data/repositories/ride_websocket_repository_impl.dart';
+import 'package:driver_app/features/rides/domain/entities/ride_dto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'dart:async';
+
+class FakeDatasource extends RidesWebSocketDatasource {
+  FakeDatasource() : super(FakeService());
+  WebSocketDto? sent;
+  @override
+  void sendRideAction(RideDto ride) {
+    sent = WebSocketDto(content: ride, typeCode: 10);
+  }
+
+  @override
+  Stream<RideDto> get rideEvents => const Stream.empty();
+}
+
+class FakeService implements WebSocketService {
+  @override
+  Stream<dynamic> get stream => const Stream.empty();
+
+  @override
+  bool get isConnected => true;
+
+  @override
+  void connect(String url, String token) {}
+
+  @override
+  void dispose() {}
+
+  @override
+  void disconnect() {}
+
+  @override
+  Stream<WebSocketDto> get webSocketDto => const Stream.empty();
+
+  @override
+  String send(WebSocketDto message) => '';
+}
+
+void main() {
+  group('RideRepositoryImpl', () {
+    test('takeRide sends type 23 message', () async {
+      final ds = FakeDatasource();
+      final repo = RideRepositoryImpl(ds);
+      await repo.takeRide({'id': 1});
+      expect(ds.sent, isNotNull);
+      expect((ds.sent!.content as RideDto).typeCode, 23);
+    });
+  });
+}

--- a/test/rides_websocket_datasource_test.dart
+++ b/test/rides_websocket_datasource_test.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+import 'package:driver_app/core/websocket/websocket_dto.dart';
+import 'package:driver_app/core/websocket/websocket_service.dart';
+import 'package:driver_app/features/rides/data/datasources/rides_websocket_datasource.dart';
+import 'package:driver_app/features/rides/domain/entities/ride_dto.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class FakeWebSocketService implements WebSocketService {
+  final StreamController<WebSocketDto> controller =
+      StreamController<WebSocketDto>.broadcast();
+
+  WebSocketDto? lastSent;
+
+  @override
+  Stream<WebSocketDto> get webSocketDto => controller.stream;
+
+  @override
+  String send(WebSocketDto message) {
+    lastSent = message;
+    controller.add(message);
+    return '';
+  }
+
+  // unused members from WebSocketService
+  @override
+  void connect(String url, String token) {}
+
+  @override
+  void dispose() {}
+
+  @override
+  void disconnect() {}
+
+  @override
+  bool get isConnected => true;
+
+  @override
+  Stream<dynamic> get stream => controller.stream;
+}
+
+void main() {
+  group('RidesWebSocketDatasource', () {
+    late FakeWebSocketService service;
+    late RidesWebSocketDatasource datasource;
+
+    setUp(() {
+      service = FakeWebSocketService();
+      datasource = RidesWebSocketDatasource(service);
+    });
+
+    test('rideEvents yields only typeCode 10 events', () async {
+      final events = <RideDto>[];
+      datasource.rideEvents.listen(events.add);
+      service.controller.add(WebSocketDto(content: {'id': 1}, typeCode: 10));
+      service.controller.add(WebSocketDto(content: {'id': 2}, typeCode: 11));
+      await Future.delayed(Duration.zero);
+      expect(events, hasLength(1));
+      expect(events.first.content['id'], 1);
+    });
+
+    test('sendRideAction forwards message through service', () async {
+      final ride = RideDto(typeCode: 23, content: {'id': 3});
+      datasource.sendRideAction(ride);
+      expect(service.lastSent, isNotNull);
+      expect(service.lastSent!.typeCode, 10); // wrapper type
+      expect(service.lastSent!.content, ride);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add unit tests for HTTP response handler
- ensure Env initialization throws errors when data missing
- test AuthNotifier login and token logic
- test websocket ride datasource and repository

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b24aa23883249fdbb75c9736c20c